### PR TITLE
generalization PCK_ISSUER_NAME to match spec

### DIFF
--- a/contracts/lib/PEMCertChainLib.sol
+++ b/contracts/lib/PEMCertChainLib.sol
@@ -19,6 +19,7 @@ contract PEMCertChainLib is IPEMCertChainLib {
 
     string constant PCK_COMMON_NAME = "Intel SGX PCK Certificate";
     string constant PCK_ISSUER_NAME = "Intel SGX PCK Platform CA";
+    string constant PCK_ISSUER_NAME2 = "Intel SGX PCK Processor CA";
     bytes constant SGX_EXTENSION_OID = hex"2A864886F84D010D01";
     bytes constant TCB_OID = hex"2A864886F84D010D0102";
     bytes constant PCESVN_OID = hex"2A864886F84D010D010211";
@@ -107,7 +108,8 @@ contract PEMCertChainLib is IPEMCertChainLib {
             issuerPtr = der.firstChildOf(issuerPtr);
             issuerPtr = der.nextSiblingOf(issuerPtr);
             cert.pck.issuerName = string(der.bytesAt(issuerPtr));
-            if (!LibString.eq(cert.pck.issuerName, PCK_ISSUER_NAME)) {
+            if (!(LibString.eq(cert.pck.issuerName, PCK_ISSUER_NAME) ||
+	          LibString.eq(cert.pck.issuerName, PCK_ISSUER_NAME2))) {
                 return (false, cert);
             }
         }


### PR DESCRIPTION
I'm making this PR just to document changes I needed for this to validate the certificates generated on my local SGX machine. I don't think these should be taken as-is, probably a better way than adding one new thing at a time!